### PR TITLE
Add comparative queue benchmark with moodycamel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,13 @@ target_include_directories(spsc_queue INTERFACE
 option(SPSC_QUEUE_BUILD_TESTS "Build the project's tests" ON)
 option(SPSC_QUEUE_BUILD_EXAMPLES "Build the project's examples" ON)
 option(SPSC_QUEUE_BUILD_BENCHMARKS "Build the project's benchmarks" OFF)
+option(SPSC_QUEUE_BUILD_BENCHMARK_COMPARE "Build comparative benchmarks against other libraries" OFF)
 
 # For MacOS
-if(APPLE AND (SPSC_QUEUE_BUILD_TESTS OR SPSC_QUEUE_BUILD_EXAMPLES OR SPSC_QUEUE_BUILD_BENCHMARKS))
+if(APPLE AND (SPSC_QUEUE_BUILD_TESTS
+              OR SPSC_QUEUE_BUILD_EXAMPLES
+              OR SPSC_QUEUE_BUILD_BENCHMARKS
+              OR SPSC_QUEUE_BUILD_BENCHMARK_COMPARE))
     # Enable experimental Clang stdlib features (for std::jthreads) when
     # building tests, examples or benchmark
     # As of Apple Clang version 17.0.0, this is still required
@@ -46,7 +50,7 @@ if(SPSC_QUEUE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(SPSC_QUEUE_BUILD_BENCHMARKS)
+if(SPSC_QUEUE_BUILD_BENCHMARKS OR SPSC_QUEUE_BUILD_BENCHMARK_COMPARE)
     add_subdirectory(benchmarks)
 endif()
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file handles the building of performance benchmarks.
 
-# 1. Fetch Google Benchmark
+# 1. Fetch Google Benchmark (needed for all benchmarks)
 # Use FetchContent to download and prepare Google Benchmark. This is the modern
 # CMake approach and does not require the user to have it installed system-wide.
 include(FetchContent)
@@ -20,13 +20,35 @@ FetchContent_MakeAvailable(GoogleBenchmark)
 # 2. Find the threading library
 find_package(Threads REQUIRED)
 
-# 3. Define the benchmark executable
-add_executable(queue_benchmark queue_benchmark.cpp)
+# 3. Build the standard, internal benchmark if enabled
+if(SPSC_QUEUE_BUILD_BENCHMARKS)
+    add_executable(queue_benchmark queue_benchmark.cpp)
+    target_link_libraries(queue_benchmark PRIVATE
+        spsc_queue
+        benchmark::benchmark
+        Threads::Threads
+    )
+endif()
 
-# 4. Link the executable against our queue, Google Benchmark, and threads.
-#    The `benchmark::benchmark` target is created by FetchContent_MakeAvailable.
-target_link_libraries(queue_benchmark PRIVATE
-    spsc_queue
-    benchmark::benchmark
-    Threads::Threads
-)
+# 4. Build the new comparative benchmark if enabled
+if(SPSC_QUEUE_BUILD_BENCHMARK_COMPARE)
+    # Fetch moodycamel::ConcurrentQueue
+    FetchContent_Declare(
+        MoodycamelConcurrentQueue
+        GIT_REPOSITORY https://github.com/cameron314/readerwriterqueue.git
+        GIT_TAG        v1.0.7 # Use a specific tag for stability
+    )
+    FetchContent_MakeAvailable(MoodycamelConcurrentQueue)
+
+    # Define the comparative benchmark executable
+    add_executable(queue_comparison_benchmark queue_comparison_benchmark.cpp)
+
+    # Link it against our queue, the moodycamel queue, Google Benchmark, and threads
+    target_link_libraries(queue_comparison_benchmark PRIVATE
+        spsc_queue
+        readerwriterqueue
+        benchmark::benchmark
+        Threads::Threads
+    )
+endif()
+


### PR DESCRIPTION
Introduces a new benchmark (queue_comparison_benchmark.cpp) to compare the performance of LockFreeSpscQueue with moodycamel::ReaderWriterQueue using Google Benchmark. Updates CMake to add a SPSC_QUEUE_BUILD_BENCHMARK_COMPARE option, fetches moodycamel's queue if enabled, and builds the new benchmark executable. Existing benchmark logic is refactored to support conditional builds for standard and comparative benchmarks.